### PR TITLE
refactor requirement files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ mixsea
 .. image:: https://img.shields.io/pypi/v/mixsea.svg
         :target: https://pypi.python.org/pypi/mixsea
 
-.. image:: https://img.shields.io/travis/modscripps/mixsea.svg
+.. image:: https://travis-ci.com/modscripps/mixsea.svg?branch=master
         :target: https://travis-ci.com/modscripps/mixsea
 
 .. image:: https://readthedocs.org/projects/mixsea/badge/?version=latest

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,7 @@
 name: mixsea
 dependencies:
   - python=3.8
-  - numpy>=1.15
-  - scipy
-  - gsw
-  - ipython
   - pip
   - pip:
+    - -r file:requirements.txt
     - -r file:requirements_dev.txt

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -20,6 +20,6 @@ sphinx:
 python:
   version: 3.6
   install:
-    - requirements: requirements.txt
+    - requirements: requirements_rtfd.txt
     - method: pip
       path: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
 numpy>=1.15
 gsw
 scipy
-matplotlib
-ipython
-sphinxcontrib-bibtex

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,3 +14,5 @@ argh
 black
 isort
 pre-commit
+matplotlib
+ipython

--- a/requirements_rtfd.txt
+++ b/requirements_rtfd.txt
@@ -1,0 +1,6 @@
+numpy>=1.15
+gsw
+scipy
+matplotlib
+ipython
+sphinxcontrib-bibtex


### PR DESCRIPTION
Moved to installing pretty much everything with pip.
Conda installs only pip and then pull from the requirement
files. Readthedocs has its own requirement file.

Also fixed the little badge for travis-ci in README.rst