### PR TITLE
reorganise gitignore using a standard example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,59 @@
-.DS_Store
-mixsea.egg-info/
-docs/_build/
-docs/.ipynb_checkpoints/
-docs/generated/
-.tox
-.vscode
+# Misc
 scratch/
+
+# IDEs
+.DS_Store
+.vscode
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Sphinx documentation
+docs/_build/
+docs/generated/
+
+# Jupyter Notebook
+.ipynb_checkpoints


### PR DESCRIPTION
I expanded the gitignore copying directly from a standard example: https://github.com/github/gitignore/blob/master/Python.gitignore