### PR TITLE
Refactor n2 thorpe

### DIFF
--- a/docs/thorpe_detailed_look.ipynb
+++ b/docs/thorpe_detailed_look.ipynb
@@ -268,6 +268,20 @@
     "use_ip = False\n",
     "\n",
     "# Choose buoyancy frequency method\n",
+    "Nsq_method = \"teosp1\"\n",
+    "eps_teosp1, n2_teosp1 = mx.overturn.eps_overturn(\n",
+    "    p,\n",
+    "    t,\n",
+    "    s,\n",
+    "    lon,\n",
+    "    lat,\n",
+    "    dnoise,\n",
+    "    alpha_sq,\n",
+    "    background_eps,\n",
+    "    use_ip=use_ip,\n",
+    "    Nsq_method=Nsq_method,\n",
+    ")\n",
+    "\n",
     "Nsq_method = \"teos\"\n",
     "eps_teos, n2_teos = mx.overturn.eps_overturn(\n",
     "    p,\n",
@@ -317,7 +331,8 @@
    "source": [
     "A brief explanation of the methods:\n",
     "\n",
-    "* `teos`: This method estimates $N^2$ from the thermodynamic equation of state 2010 (TEOS), using the tempurature and salinity just before and after the overturn.\n",
+    "* `teos`: This method estimates $N^2$ from the thermodynamic equation of state 2010 (TEOS), using the tempurature and salinity at the first and last point in the overturn.\n",
+    "* `toesp1`: This method is the same as above except it uses the temperature and salinity from the points immediately above and below overturn (p1 meaning plus 1).\n",
     "* `bulk`: This method comes from <cite data-cite=\"Smyth2001\">Smyth et al. (2001)</cite> and has the advantage of being insensitive to errors in determining the patch size. Buoyancy frequency is proportional to the root mean square density anomaly of an overturn, divided by the Thorpe scale.\n",
     "* `endpt`: This simple method estimates buoyancy frequency from the potential density gradient across each overturn."
    ]
@@ -336,9 +351,11 @@
     "fig, axs = plt.subplots(1, 3, sharey=True, figsize=(9, 6))\n",
     "axs[0].plot(diag[\"dens\"][cut], zc, label=\"density\")\n",
     "axs[0].plot(diag[\"dens_sorted\"][cut], zc, label=\"sorted density\")\n",
+    "axs[1].plot(eps_teosp1[cut], zc, label=\"teosp1\")\n",
     "axs[1].plot(eps_teos[cut], zc, label=\"teos\")\n",
     "axs[1].plot(eps_bulk[cut], zc, label=\"bulk\")\n",
     "axs[1].plot(eps_endpt[cut], zc, label=\"endpt\")\n",
+    "axs[2].plot(n2_teosp1[cut], zc, label=\"teosp1\")\n",
     "axs[2].plot(n2_teos[cut], zc, label=\"teos\")\n",
     "axs[2].plot(n2_bulk[cut], zc, label=\"bulk\")\n",
     "axs[2].plot(n2_endpt[cut], zc, label=\"endpt\")\n",
@@ -358,7 +375,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The different methods can alter the dissipation rate estimate by almost an order of magnitude."
+    "The different methods can alter the dissipation rate estimate by almost an order of magnitude. The `endpt` and `teos` methods give such similar results they are indistinguishable. The `teosp1` method tends to result in higher $N^2$ estimates, because there is often a jump in stratification adjacent to an overturning patch. "
    ]
   }
  ],


### PR DESCRIPTION
This pull does two things:

* Modify `teos` method of estimating N2 so that it does not use points beyond the overturn but instead uses the end points of the overturn. Ultimately this is almost identical to `endpt`. 

* Rename the method that was previous `teos` to `teosp1` where the p1 means 'plus 1', i.e. it goes one point beyond the overturn to estimate N squared. It turns out this makes a huge difference to the epsilon estimate! For our first release I think we should choose defaults carefully. I left the default as `teosp1` for consistency with previous code but I think it would be better to use `bulk` or `endpt` for the release. 