### PR TITLE
Add function `nan_shearstrain`.

### DIFF
--- a/docs/shearstrain_details.ipynb
+++ b/docs/shearstrain_details.ipynb
@@ -119,7 +119,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Our example data contain some NaN values, as is common with observational datasets. Below we isolate the good data by removing NaNs."
+    "Our example data contain some NaN values, as is common with observational datasets. Below we isolate the good data by removing NaNs. See the section [Missing Data](#missing_data) for using `nan_shearstrain` with input data that contains NaNs."
    ]
   },
   {
@@ -133,6 +133,7 @@
     "    notnan = np.vstack(notnan)\n",
     "    notnan = np.all(notnan, axis=0)\n",
     "    return notnan\n",
+    "\n",
     "\n",
     "notnan = nonan(ctd)\n",
     "p = ctd[\"p\"][notnan]\n",
@@ -316,7 +317,7 @@
    "outputs": [],
    "source": [
     "eps_shst, krho_shst, diag = mx.shearstrain.shearstrain(\n",
-    "    s, t, p, z, lat, lon, uz, vz, zz, smooth='PF', **shst_params\n",
+    "    s, t, p, z, lat, lon, uz, vz, zz, smooth=\"PF\", **shst_params\n",
     ")"
    ]
   },
@@ -339,7 +340,7 @@
    "outputs": [],
    "source": [
     "eps_shst2, krho_shst2, diag2 = mx.shearstrain.shearstrain(\n",
-    "    s, t, p, z, lat, lon, uz, vz, zz, smooth='AL', **shst_params\n",
+    "    s, t, p, z, lat, lon, uz, vz, zz, smooth=\"AL\", **shst_params\n",
     ")"
    ]
   },
@@ -386,11 +387,90 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='missing_data'></a>\n",
+    "## Missing Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we pass the data as is, containing NaNs, to `nan_shearstrain`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "eps_shst3, krho_shst3, diag3 = mx.shearstrain.nan_shearstrain(\n",
+    "    ctd[\"s\"],\n",
+    "    ctd[\"t\"],\n",
+    "    ctd[\"p\"],\n",
+    "    ctd[\"z\"],\n",
+    "    ctd[\"lat\"],\n",
+    "    ctd[\"lon\"],\n",
+    "    ladcp[\"uz\"],\n",
+    "    ladcp[\"vz\"],\n",
+    "    ladcp[\"z\"],\n",
+    "    smooth=\"PF\",\n",
+    "    **shst_params\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compare with result of `shearstrain` from above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "janus": {
+     "all_versions_showing": false,
+     "cell_hidden": false,
+     "current_version": 0,
+     "id": "ce67995fee7888",
+     "named_versions": [],
+     "output_hidden": false,
+     "show_versions": false,
+     "source_hidden": false,
+     "versions": []
+    }
+   },
+   "outputs": [],
+   "source": [
+    "z_bin = diag[\"z_bin\"]\n",
+    "z_bin3 = diag3[\"z_bin\"]\n",
+    "fig, ax = plt.subplots(\n",
+    "    nrows=1, ncols=2, figsize=(6, 4), constrained_layout=True, sharey=True\n",
+    ")\n",
+    "opts = dict(drawstyle=\"steps-mid\")\n",
+    "# shear/strain\n",
+    "ax[0].plot(eps_shst, z_bin, label=\"shear/strain PF\", **opts)\n",
+    "ax[0].plot(eps_shst3, z_bin3, label=\"shear/strain PF\", linestyle=\"--\", **opts)\n",
+    "ax[0].legend()\n",
+    "ax[0].set(\n",
+    "    xscale=\"log\", xlabel=r\"$\\epsilon$ [W/kg]\", ylabel=\"depth [m]\",\n",
+    ")\n",
+    "# strain only\n",
+    "eps_st = diag[\"eps_st\"]\n",
+    "eps_st3 = diag3[\"eps_st\"]\n",
+    "ax[1].plot(eps_st, z_bin, label=\"strain only PF\", **opts)\n",
+    "ax[1].plot(eps_st3, z_bin3, label=\"strain only PF\", linestyle=\"--\", **opts)\n",
+    "ax[1].legend()\n",
+    "ax[1].set(\n",
+    "    xscale=\"log\", xlabel=r\"$\\epsilon$ [W/kg]\",\n",
+    ")\n",
+    "ax[0].invert_yaxis()"
+   ]
   }
  ],
  "metadata": {

--- a/mixsea/tests/test_shearstrain.py
+++ b/mixsea/tests/test_shearstrain.py
@@ -6,8 +6,9 @@ from mixsea import shearstrain
 
 # Use the ctd and ladcp profile defined as fixture in conftest.py
 # Run the test both for adiabatic leveling and polynomial fit method.
+# Use `nan_shearstrain` as the data contain NaNs.
 @pytest.mark.parametrize("smooth", ["AL", "PF"])
-def test_shearstrain(ctd_profile, ladcp_profile, smooth):
+def test_nan_shearstrain(ctd_profile, ladcp_profile, smooth):
     assert ctd_profile["lon"].shape == ctd_profile["lat"].shape
     # Center points of depth windows. Windows are half overlapping, i.e.
     # their size (300m) is double the spacing here (150m).
@@ -23,7 +24,7 @@ def test_shearstrain(ctd_profile, ladcp_profile, smooth):
     m_include_sh = list(range(3))
     m_include_st = list(range(1, 10))
 
-    (eps_shst, krho_shst, diag,) = shearstrain.shearstrain(
+    (eps_shst, krho_shst, diag,) = shearstrain.nan_shearstrain(
         ctd_profile["s"],
         ctd_profile["t"],
         ctd_profile["p"],
@@ -44,3 +45,63 @@ def test_shearstrain(ctd_profile, ladcp_profile, smooth):
 
     assert np.nanmean(np.log10(eps_shst)) < 0
     assert np.nanmean(np.log10(diag["eps_st"])) < 0
+
+
+# Remove NaNs manually and use `shearstrain`.
+def test_shearstrain(ctd_profile, ladcp_profile):
+    ctd = ctd_profile
+    notnan = nonan(ctd)
+    p = ctd["p"][notnan]
+    z = ctd["z"][notnan]
+    t = ctd["t"][notnan]
+    s = ctd["s"][notnan]
+    lon = ctd["lon"][0]
+    lat = ctd["lat"][0]
+    ladcp = ladcp_profile
+    notnan = nonan(ladcp)
+    uz = ladcp["uz"][notnan]
+    vz = ladcp["vz"][notnan]
+    zz = ladcp["z"][notnan]
+
+    # Center points of depth windows. Windows are half overlapping, i.e.
+    # their size (300m) is double the spacing here (150m).
+    window_size = 300
+    dz = window_size / 2
+    zbin = np.linspace(dz, dz * 40, num=40)
+    # Wavenumber vector. Starts at wavenumber corresponding to window size.
+    m = np.arange(
+        start=2 * np.pi / window_size, stop=2 * np.pi / 10, step=2 * np.pi / window_size
+    )
+    # Wavenumber indices for integration. Shear is integrated from 300m to
+    # 100m scales. Strain is integrated from 150m to 30m.
+    m_include_sh = list(range(3))
+    m_include_st = list(range(1, 10))
+
+    (eps_shst, krho_shst, diag,) = shearstrain.shearstrain(
+        s,
+        t,
+        p,
+        z,
+        lat,
+        lon,
+        uz,
+        vz,
+        zz,
+        m=m,
+        z_bin=zbin,
+        m_include_sh=m_include_sh,
+        m_include_st=m_include_st,
+        ladcp_is_shear=True,
+        smooth="PF",
+        return_diagnostics=True,
+    )
+
+    assert np.nanmean(np.log10(eps_shst)) < 0
+    assert np.nanmean(np.log10(diag["eps_st"])) < 0
+
+
+def nonan(data):
+    notnan = [np.isfinite(v) for k, v in data.items()]
+    notnan = np.vstack(notnan)
+    notnan = np.all(notnan, axis=0)
+    return notnan


### PR DESCRIPTION
Closes #31.
- `nan_shearstrain` wraps `shearstrain`.
- Throw a ValueError in `shearstrain` if input data contains NaNs.
- Output strain, strain depth vector, integration results in
  diagnostics.