### PR TITLE
Isolated Thorpe scale calculation to address #75

### DIFF
--- a/docs/thorpe_scales.ipynb
+++ b/docs/thorpe_scales.ipynb
@@ -518,7 +518,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/environment_rtfd.yml
+++ b/environment_rtfd.yml
@@ -8,6 +8,6 @@ dependencies:
   - scipy
   - matplotlib
   - ipykernel
-  - sphinxcontrib-bibtex
+  - sphinxcontrib-bibtex<2.0.0
   - nbsphinx
   - pandoc

--- a/mixsea/nsq.py
+++ b/mixsea/nsq.py
@@ -140,7 +140,15 @@ def nsqfcn(s, t, p, p0, dp, lon, lat):
 
 
 def adiabatic_leveling(
-    P, S, T, lon, lat, bin_width=100.0, order=1, return_diagnostics=False, cap=None,
+    P,
+    S,
+    T,
+    lon,
+    lat,
+    bin_width=100.0,
+    order=1,
+    return_diagnostics=False,
+    cap=None,
 ):
     """Generate smooth buoyancy frequency profile by adiabatic leveling.
 

--- a/mixsea/overturn.py
+++ b/mixsea/overturn.py
@@ -93,7 +93,7 @@ def eps_overturn(
     lat : float
         Latitude of observation
     dnoise : float, optional
-        Noise level of density [kg/m^3]. Default is 5e-4.
+        Noise level of density [kg/m^3] or conservative temperature [°C], depending on overturns_from_CT. Default is 5e-4.
     alpha : float, optional
         Constant of proportionality between Thorpe and Ozmidov scale. Default is 0.95.
     Roc : float, optional
@@ -357,6 +357,9 @@ def thorpe_scale(depth, q, dnoise):
     patches : ndarray
         Indices of overturning patches, e.g. patches[:, 0] are start indices and patches[:, 1] are end indices.
     """
+    
+    depth = np.asarray(depth)
+    q = np.asarray(q)
     
     if q[0] > q[-1]:
         raise ValueError("The entire profile is unstable, q[0] > q[-1].")

--- a/mixsea/overturn.py
+++ b/mixsea/overturn.py
@@ -102,7 +102,7 @@ def eps_overturn(
     background_eps : float, optional
         Background epsilon where no overturn detected. Defaults to numpy.nan.
     use_ip : bool, optional
-        Sets whether to use the intermediate profile method. Default is True. If True,
+        Sets whether to use the intermediate profile method. Default is False. If True,
         the dnoise parameter is passed as the `accuracy' argument of the intermediate
         profile method.
     N2_method : string, optional
@@ -117,9 +117,9 @@ def eps_overturn(
 
     Returns
     -------
-    eps : array-like
+    eps : ndarray
         Turbulent dissipation [W/kg]
-    N2 : array-like
+    N2 : ndarray
         Background stratification of each overturn detected [s^-2]
     diag : dict, optional
         Dictionary of diagnositc variables, set return with the `return_diagnostics' argument.
@@ -211,23 +211,16 @@ def eps_overturn(
             q = dens
 
         if use_ip:  # Create intermediate density profile
-            q_ip = intermediate_profile(
+            q = intermediate_profile(
                 q, acc=dnoise, hinge=1000, kind="down"
             )  # TODO: make hinge optional
-            sidx, patches = find_overturns(
-                q_ip, combine_gap=0
-            )  # Also, combine gap should be a parameter...
-        else:
-            sidx, patches = find_overturns(q, combine_gap=0)
+            
+        # --->> THORPE SCALES <<---
+        Lt, thorpe_disp, q_sorted, noise_flag, ends_flag, Ro, patches, sidx = thorpe_scale(depth, q, dnoise)
 
         # If there are no overturns, move on to the next pressure bin.
         if not np.any(patches):
             continue
-
-        # Thorpe displacements
-        thorpe_disp = depth[sidx] - depth
-
-        q_sorted = q[sidx]
 
         # Sort other quantities based on the sorting indices.
         dens_sorted = dens[sidx]
@@ -235,23 +228,15 @@ def eps_overturn(
         CT_sorted = CT[sidx]
 
         # Temporary arrays.
-        Lt = np.full_like(depth, np.nan)
         N2 = np.full_like(depth, np.nan)
-        Ro = np.full_like(depth, np.nan)
-        noise_flag = np.full_like(depth, False, dtype=bool)
         N2_flag = np.full_like(depth, False, dtype=bool)
-        ends_flag = np.full_like(depth, False, dtype=bool)
         Ro_flag = np.full_like(depth, False, dtype=bool)
 
         for patch in patches:
             # Get patch indices.
             i0 = patch[0]
             i1 = patch[1] + 1  # Need +1 for last point in overturn.
-            pidx = np.arange(i0, i1 + 1, 1)
-
-            # Thorpe scale is the root mean square thorpe displacement.
-            Lto = np.sqrt(np.mean(np.square(thorpe_disp[pidx])))
-            Lt[pidx] = Lto
+            pidx = np.arange(i0, i1, 1)
 
             # Estimate the buoyancy frequency.
             if N2_method == "teos":
@@ -284,34 +269,13 @@ def eps_overturn(
 
             N2[pidx] = N2o
 
-            # Flag beginning or end.
-            if i0 == 0:
-                ends_flag[pidx] = True
-            if i1 == ndata - 1:
-                ends_flag[pidx] = True
-
-            # Flag small density or CT difference.
-            if not use_ip:
-                dq = q_sorted[i1] - q_sorted[i0]
-                if dq < dnoise:
-                    noise_flag[pidx] = True
-
             # Flag negative N squared.
             if N2o < 0:
                 N2_flag[pidx] = True
-
-            # Overturn ratio of Gargett & Garner
-            Tdo = thorpe_disp[pidx]
-            dzo = dz[pidx]
-            L_tot = np.sum(dzo)
-            L_neg = np.sum(dzo[Tdo < 0])
-            L_pos = np.sum(dzo[Tdo > 0])
-            Roo = np.minimum(L_neg / L_tot, L_pos / L_tot)
-            Ro[pidx] = Roo
-            # Don't raise flag if using intermediate profile because
-            # the method leads to sorting weirdness that messes with
-            # the overturn ratio.
-            if Roo < Roc and not use_ip:
+                
+            Roo = np.unique(Ro[pidx])
+            
+            if Roo < Roc:
                 Ro_flag[pidx] = True
 
         # Find and select data for this reference pressure range only.
@@ -334,10 +298,10 @@ def eps_overturn(
         diag["SA_sorted"][inbin] = SA_sorted[inbin]
 
         if use_ip and not overturns_from_CT:
-            diag["dens_ip"][inbin] = q_ip[inbin]
+            diag["dens_ip"][inbin] = q[inbin]
 
         if use_ip and overturns_from_CT:
-            diag["CT_ip"][inbin] = q_ip[inbin]
+            diag["CT_ip"][inbin] = q[inbin]
 
     # Finally calculate epsilon for diagnostics, avoid nans, inf and negative N2.
     isgood = np.isfinite(diag["N2"]) & np.isfinite(diag["Lt"]) & ~diag["N2_flag"]
@@ -359,6 +323,98 @@ def eps_overturn(
         return eps, N2, diag
     else:
         return eps, N2
+    
+    
+def thorpe_scale(depth, q, dnoise):
+    """
+    Estimate the Thorpe scale from unstable patches in a profile.
+
+    Parameters
+    ----------
+    depth : array-like
+        Depth [m]
+    q : array-like
+        Quantity from which Thorpe scales will be computed, e.g. density or temperature. If using 
+        temperature, consider multiplying by -1 to get around the fact that temperature generally 
+        decreases with depth. 
+    dnoise : float, optional
+        Uncertainty or noise in q.
+
+    Returns
+    -------
+    Lt : ndarray
+        Thorpe scale [m]
+    thorpe_disp : ndarray
+        Thorpe displacement [m]
+    q_sorted : ndarray
+        q sorted to be monotonically increasing
+    noise_flag : ndarray
+        True if difference in q from top to bottom patch is less than dnoise
+    ends_flag : ndarray
+        True if a patch includes and end point
+    Ro : ndarray
+        Overturn ratio of Gargett & Garner.
+    patches : ndarray
+        Indices of overturning patches, e.g. patches[:, 0] are start indices and patches[:, 1] are end indices.
+    """
+    
+    if q[0] > q[-1]:
+        raise ValueError("The entire profile is unstable, q[0] > q[-1].")
+        
+    if not np.all(np.isclose(np.maximum.accumulate(depth), depth)):
+        raise ValueError(
+            "It appears that depth is not monotonically increasing, please fix."
+        )
+
+    idx_sorted, patches = find_overturns(q, combine_gap=0)
+    
+    ndata = depth.size
+
+    # Thorpe displacements
+    thorpe_disp = depth[idx_sorted] - depth
+
+    q_sorted = q[idx_sorted]
+
+    # Initialise arrays.
+    Lt = np.full_like(depth, np.nan)
+    Ro = np.full_like(depth, np.nan)
+    noise_flag = np.full_like(depth, False, dtype=bool)
+    ends_flag = np.full_like(depth, False, dtype=bool)
+    
+    dz = 0.5 * (depth[2:] - depth[:-2])  # 'width' of each data point
+    dz = np.hstack((dz[0], dz, dz[-1]))  # assume width of first and last data point
+
+    for patch in patches:
+        # Get patch indices.
+        i0 = patch[0]
+        i1 = patch[1] + 1  # Need +1 for last point in overturn.
+        pidx = np.arange(i0, i1, 1)
+
+        # Thorpe scale is the root mean square thorpe displacement.
+        Lto = np.sqrt(np.mean(np.square(thorpe_disp[pidx])))
+        Lt[pidx] = Lto
+
+        # Flag beginning or end.
+        if i0 == 0:
+            ends_flag[pidx] = True
+        if i1 == ndata - 1:
+            ends_flag[pidx] = True
+
+        # Flag small difference.
+        dq = q_sorted[i1] - q_sorted[i0]
+        if dq < dnoise:
+            noise_flag[pidx] = True
+
+        # Overturn ratio of Gargett & Garner
+        Tdo = thorpe_disp[pidx]
+        dzo = dz[pidx]
+        L_tot = np.sum(dzo)
+        L_neg = np.sum(dzo[Tdo < 0])
+        L_pos = np.sum(dzo[Tdo > 0])
+        Roo = np.minimum(L_neg / L_tot, L_pos / L_tot)
+        Ro[pidx] = Roo
+
+    return Lt, thorpe_disp, q_sorted, noise_flag, ends_flag, Ro, patches, idx_sorted
 
 
 def find_overturns(q, combine_gap=0):
@@ -375,9 +431,9 @@ def find_overturns(q, combine_gap=0):
 
     Returns
     -------
-    idx_sorted : 1D numpy array
+    idx_sorted : 1D ndarray
         Indices that sort the data q.
-    idx_patches : (N, 2) numpy array
+    idx_patches : (N, 2) ndarray
         Start and end indices of the overturns.
 
     """
@@ -406,7 +462,7 @@ def intermediate_profile_topdown(q, acc, hinge):
 
     Returns
     -------
-    qi : 1D numpy array
+    qi : 1D ndarray
         Intermediate profile.
 
     """
@@ -446,7 +502,7 @@ def intermediate_profile(q, acc=5e-4, hinge=1000, kind="down"):
 
     Returns
     -------
-    qi : 1D numpy array
+    qi : 1D ndarray
         Intermediate profile.
 
     """

--- a/mixsea/tests/test_overturn.py
+++ b/mixsea/tests/test_overturn.py
@@ -24,38 +24,46 @@ def test_overturn_const_s(ctd_profile):
         ctd_profile["lat"][0],
     )
     assert np.nanmean(eps) < 1e-4
-    
-    
+
+
 def test_thorpe_scale():
-    dz = 1.
-    z0 = -2200.
-    H = 100.
-    h = 50.
-    z = np.arange(z0+H, z0-H, -dz)
+    dz = 1.0
+    z0 = -2200.0
+    H = 100.0
+    h = 50.0
+    z = np.arange(z0 + H, z0 - H, -dz)
     rho_0 = 1041.4
     delta = 1e-4
 
-    top = ((z0 + H) >= z) & (z >= (z0 + h)) 
+    top = ((z0 + H) >= z) & (z >= (z0 + h))
     middle = ((z0 + h) > z) & (z > (z0 - h))
     bottom = ((z0 - h) >= z) & (z >= (z0 - H))
 
     # Thorpe 77 profile
     rho = np.zeros_like(z)
-    rho[top] = rho_0*(1 - delta)
-    rho[middle] = rho_0*(1 + delta*np.sin(3*np.pi*(z[middle] + z0)/(2*h)))
-    rho[bottom] = rho_0*(1 + delta)
+    rho[top] = rho_0 * (1 - delta)
+    rho[middle] = rho_0 * (1 + delta * np.sin(3 * np.pi * (z[middle] + z0) / (2 * h)))
+    rho[bottom] = rho_0 * (1 + delta)
 
-    # Thorpe 77 analytical solution 
+    # Thorpe 77 analytical solution
     rho_s = np.zeros_like(z)
     rho_s[top] = rho[top]
-    rho_s[middle] = rho_0*(1 - delta*np.sin(np.pi*(z[middle] + z0)/(2*h)))
+    rho_s[middle] = rho_0 * (1 - delta * np.sin(np.pi * (z[middle] + z0) / (2 * h)))
     rho_s[bottom] = rho[bottom]
-    
-    Lt, thorpe_disp, q_sorted, noise_flag, ends_flag, Ro, patches, idx_sorted = overturn.thorpe_scale(-z, rho, 0)
-    
+
+    (
+        Lt,
+        thorpe_disp,
+        q_sorted,
+        noise_flag,
+        ends_flag,
+        Ro,
+        patches,
+        idx_sorted,
+    ) = overturn.thorpe_scale(-z, rho, 0)
+
     notnan = ~np.isnan(Lt)
-    
+
     assert np.isclose(q_sorted, rho_s).all()
     # assert np.isclose(np.unique(out["Lt"][notnan]), (8*h/9)*(1 + (3/np.pi**2)*(np.pi**2 - 8))**0.5) <- THIS FAILS, COULD BE A BIG ISSUE??
     assert np.isclose(np.unique(Ro[notnan]), 0.5, atol=0.02)
-           

--- a/mixsea/tests/test_overturn.py
+++ b/mixsea/tests/test_overturn.py
@@ -24,3 +24,38 @@ def test_overturn_const_s(ctd_profile):
         ctd_profile["lat"][0],
     )
     assert np.nanmean(eps) < 1e-4
+    
+    
+def test_thorpe_scale():
+    dz = 1.
+    z0 = -2200.
+    H = 100.
+    h = 50.
+    z = np.arange(z0+H, z0-H, -dz)
+    rho_0 = 1041.4
+    delta = 1e-4
+
+    top = ((z0 + H) >= z) & (z >= (z0 + h)) 
+    middle = ((z0 + h) > z) & (z > (z0 - h))
+    bottom = ((z0 - h) >= z) & (z >= (z0 - H))
+
+    # Thorpe 77 profile
+    rho = np.zeros_like(z)
+    rho[top] = rho_0*(1 - delta)
+    rho[middle] = rho_0*(1 + delta*np.sin(3*np.pi*(z[middle] + z0)/(2*h)))
+    rho[bottom] = rho_0*(1 + delta)
+
+    # Thorpe 77 analytical solution 
+    rho_s = np.zeros_like(z)
+    rho_s[top] = rho[top]
+    rho_s[middle] = rho_0*(1 - delta*np.sin(np.pi*(z[middle] + z0)/(2*h)))
+    rho_s[bottom] = rho[bottom]
+    
+    Lt, thorpe_disp, q_sorted, noise_flag, ends_flag, Ro, patches, idx_sorted = overturn.thorpe_scale(-z, rho, 0)
+    
+    notnan = ~np.isnan(Lt)
+    
+    assert np.isclose(q_sorted, rho_s).all()
+    # assert np.isclose(np.unique(out["Lt"][notnan]), (8*h/9)*(1 + (3/np.pi**2)*(np.pi**2 - 8))**0.5) <- THIS FAILS, COULD BE A BIG ISSUE??
+    assert np.isclose(np.unique(Ro[notnan]), 0.5, atol=0.02)
+           


### PR DESCRIPTION
Added a new function called `thorpe_scale`, which can take arbitrary quantity as input. Hopefully this goes some way to addressing #75. I added the Thorpe 77 analytical solution as a unit test for this, which actually raised a different unrelated issue. 

I threw in a few typo fixes e.g. #70 

Also added specific bibtex version in the environment because readthedocs was failing to build. 