### PR TITLE
Simplify overturn helper functions and unify variable names.

### DIFF
--- a/mixsea/overturn.py
+++ b/mixsea/overturn.py
@@ -447,17 +447,15 @@ def thorpe_scale(depth, q, dnoise):
     return Lt, thorpe_disp, q_sorted, noise_flag, ends_flag, Ro, idx_patches, idx_sorted
 
 
-def find_overturns(q, combine_gap=0):
-    """Find the indices of unstable patches.
+def find_overturns(q):
+    """Find the indices of unstable patches by cumulatively summing the difference between
+    sorted and unsorted indices of q.
 
     Parameters
     ----------
     q : array_like 1D
             Profile of some quantity from which overturns can be detected
             e.g. temperature or density.
-    combine_gap : float, optional
-            Combine overturns that are separated by less than a given number of points.
-            Default is 0.
 
     Returns
     -------

--- a/mixsea/overturn.py
+++ b/mixsea/overturn.py
@@ -396,7 +396,7 @@ def thorpe_scale(depth, q, dnoise):
             "It appears that depth is not monotonically increasing, please fix."
         )
 
-    idx_sorted, idx_patches = find_overturns(q, combine_gap=0)
+    idx_sorted, idx_patches = find_overturns(q)
 
     ndata = depth.size
 

--- a/mixsea/tests/test_overturn.py
+++ b/mixsea/tests/test_overturn.py
@@ -72,3 +72,12 @@ def test_thorpe_scale():
     assert np.isclose(q_sorted, rho_s).all()
     assert np.isclose(np.unique(Lt[inoverturn])[0], Lt_analytical)
     assert np.isclose(np.unique(Ro[inoverturn])[0], 0.5, atol=0.02)
+
+
+def test_contiguous_regions():
+    condition = np.array(
+        [True, True, False, False, True, True, True, False, True, True]
+    )
+    idx = np.array([[0, 2], [4, 7], [8, 10]])
+
+    assert np.all(overturn.contiguous_regions(condition) == idx)


### PR DESCRIPTION
In an attempt to address #92 and partially address #83 I have: 

* Replaced the `_consec_blocks` function, the functionality of which was only partially used, with `contiguous_regions` that finds the indices of contiguous True values in a 1D array in a vectorised way. 
* Included a test for `contiguous_regions`.
* Unified the disparate variable names for patch indicies (see #92) to be more consistent. 
* Added some minor docstring fixes. 