### PR TITLE
Fix frequency shift bug in psd

### DIFF
--- a/mixsea/helpers.py
+++ b/mixsea/helpers.py
@@ -166,16 +166,16 @@ def psd(
             window=window,
             return_onesided=False,
         )
-        # One side of 0 is shifted to negative values - need to shift back
-        f0[f0 < 0] = f0[f0 < 0] + 1
-        # Since we've shifted the wavenumber near zero to near one, we need to
-        # extend it fully to one for interpolation to work below. Technically,
-        # this should be the same as interpolating from zero to a very small
-        # value.
-        f0[-1] = 1
+
+        # One side of f0 is shifted to negative values - shift everything to
+        # positive.
+        f0 = np.fft.fftshift(f0) + np.absolute(f0).max()
+
+        # Interpolate to f_full frequency vector
         Pxx0 = interp1d(f0, Pxx0, bounds_error=False, axis=-1)(f_full)
         Pxx = Pxx0.copy()
         Pxx = Pxx / 2 / np.pi  # normalize by radial wavenumber/frequency
+
     # Separate into cw and ccw spectra
     if np.remainder(M[1], 2) == 0:
         # even lengths, divide 0 and nyquist freq between ccw and cw


### PR DESCRIPTION
scipy.signal.welch outputs negative frequencies. These were not shifted
properly to positive values which resulted in wrong power spectral
density output (basically) for one side of the spectrum.

Closes #104